### PR TITLE
Fix ROLZX index-out-of-range panic on DNA-detected data

### DIFF
--- a/v2/transform/ROLZCodec.go
+++ b/v2/transform/ROLZCodec.go
@@ -1153,8 +1153,9 @@ func (this *rolzCodec2) Forward(src, dst []byte) (uint, uint, error) {
 			delta = 3
 			flags |= 8
 		} else if dt == internal.DT_DNA {
+			delta = 8
 			this.minMatch = _ROLZ_MIN_MATCH7
-			flags = 1
+			flags |= 4
 		}
 	}
 

--- a/v2/transform/Transforms_test.go
+++ b/v2/transform/Transforms_test.go
@@ -291,6 +291,63 @@ func TestROLZInverseLiteralOnlyChunkAfterCompressedChunk(t *testing.T) {
 	}
 }
 
+// ROLZX detects ACGT as DNA and hashes 8 bytes (getKey2); the DNA branch must read
+// backward (delta=8) and tag the block (flags|=4), else it overran the buffer near
+// the chunk end. Mirrors rolzCodec1 and the C++/Java references.
+func TestROLZXDNARoundTrip(t *testing.T) {
+	acgt := []byte("ACGT")
+
+	for _, size := range []int{_ROLZ_MIN_BLOCK_SIZE, 65, 70, 128, 256, 1024, 4096, 70000} {
+		t.Run(fmt.Sprintf("size%d", size), func(t *testing.T) {
+			input := make([]byte, size)
+			for i := range input {
+				input[i] = acgt[i&3]
+			}
+
+			fwd, err := getTransform("ROLZX")
+			if err != nil {
+				t.Fatalf("create ROLZX transform: %v", err)
+			}
+
+			output := make([]byte, fwd.MaxEncodedLen(size))
+			var dstIdx uint
+
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						t.Fatalf("ROLZX forward panicked on DNA data (size=%d): %v", size, r)
+					}
+				}()
+				_, dstIdx, err = fwd.Forward(input, output)
+			}()
+
+			if err != nil {
+				t.Fatalf("forward ROLZX on DNA data (size=%d): %v", size, err)
+			}
+
+			if output[4]&0x0E != 4 {
+				t.Fatalf("data not tagged as DNA: header flags=%#x", output[4])
+			}
+
+			inv, err := getTransform("ROLZX")
+			if err != nil {
+				t.Fatalf("create inverse ROLZX transform: %v", err)
+			}
+
+			reverse := make([]byte, size)
+			_, decoded, err := inv.Inverse(output[:dstIdx], reverse)
+
+			if err != nil {
+				t.Fatalf("inverse ROLZX on DNA data (size=%d): %v", size, err)
+			}
+
+			if decoded != uint(size) || bytes.Equal(input, reverse) == false {
+				t.Fatalf("ROLZX DNA round-trip mismatch at size %d (decoded %d)", size, decoded)
+			}
+		})
+	}
+}
+
 // generateTransformTestCases creates the suite of generic test cases.
 func generateTransformTestCases(transformName string) []transformTestCase {
 	testCases := []transformTestCase{}


### PR DESCRIPTION
`ROLZX` (`rolzCodec2`) panics with `runtime error: index out of range` when compressing input auto-detected as DNA (ACGT-dominant), so `kanzi -t ROLZX` aborts on exactly the data the DNA path targets.

The DNA branch of `rolzCodec2.Forward` sets `minMatch = _ROLZ_MIN_MATCH7`, which selects the 8-byte `getKey2` hash, but leaves `delta = 2`. `getKey2(buf[srcIdx-delta:])` then reads `[srcIdx-2, srcIdx+6)`, i.e. 6 bytes past `srcIdx`, and overruns the chunk once `srcIdx` is within a few bytes of its end.

Compared to the sibling `rolzCodec1.Forward` and the C++/Java kanzi, two things are missing in this branch: `delta = 8` (a fully-backward, in-bounds read) and the DNA data-type flag `flags |= 4`. It instead emits `flags = 1`, which the inverse — which decodes the data type via `flags & 0x0E` — does not recognize as DNA. Setting `delta = 8` and `flags |= 4` matches `rolzCodec1` and the references; the inverse already maps `flags & 0x0E == 4` to `delta=8, minMatch=7`, so no decoder change is needed and the round-trip is restored.

Repro on master:

```go
c, _ := transform.NewROLZCodecWithCtx(&map[string]any{"transform": "ROLZX"})
dst := make([]byte, c.MaxEncodedLen(64)+1024)
c.Forward(bytes.Repeat([]byte("ACGT"), 16), dst) // panic: index out of range
```

`TestROLZXDNARoundTrip` covers ACGT round-trips from the 64-byte minimum up, asserting the block is tagged DNA and `Inverse(Forward(x)) == x`; it panics on master and passes here. The existing `TestROLZX` missed this because its corpus has no DNA-shaped input.
